### PR TITLE
More packaging fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ else()
 	cmake_policy(SET CMP0048 NEW)
 	project(ibarr
 		VERSION "${LIB_VERSION_STRING}"
-		DESCRIPTION "IP 2 GID resolution over UDP"
 		LANGUAGES C)
 endif()
 set(CMAKE_C_COMPILER_NAMES gcc clang)

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Build-Depends: debhelper (>= 9),
  libibumad-dev,
  pkgconf | pkg-config,
 Standards-Version: 4.5.0
-Rules-Requires-Root: no
 Homepage: https://github.com/Mellanox/ip2gid/
 Vcs-Browser: https://github.com/Mellanox/ip2gid/
 Vcs-Git: https://github.com/Mellanox/ip2gid/

--- a/ibarr.spec
+++ b/ibarr.spec
@@ -13,6 +13,15 @@ License:	(GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause
 %if %{undefined cmake_install}
 %global cmake_install %make_install
 %endif
+%if %{undefined cmake_build}
+  %if %{defined make_jobs}
+    # SLES12
+    %global cmake_build %make_jobs
+  %else
+    # RHEL < 9, Fedora < ??
+    %global cmake_build %make_build
+  %endif
+%endif
 
 %description
 a userspace application that interacts over NetLink with the Linux RDMA
@@ -24,7 +33,7 @@ subsystem and provides 2 services: ip2gid (address resolution) and gid2lid
 
 %build
 %cmake
-%make_build
+%cmake_build
 
 %install
 %cmake_install


### PR DESCRIPTION
Tested the build on various other systems. Fails to build on SLES12SP3 and RHEL7.2 because headers are too old. RHEL7.7 and SLES12SP4 should now work, and also others. Likewise probably Debian >= 9 and Ubuntu >= 18.04 .

These fixes seem to be required.