### PR TITLE
Respect install prefix when installing systemd service file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,4 +80,4 @@ include_directories(${PROJECT_BINARY_DIR})
 
 install(TARGETS ibarr DESTINATION bin)
 
-install(FILES ibarr.service DESTINATION /lib/systemd/system)
+install(FILES ibarr.service DESTINATION lib/systemd/system)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,4 +80,5 @@ include_directories(${PROJECT_BINARY_DIR})
 
 install(TARGETS ibarr DESTINATION bin)
 
-install(FILES ibarr.service DESTINATION lib/systemd/system)
+configure_file(ibarr.service.in ibarr.service)
+install(FILES ${CMAKE_BINARY_DIR}/ibarr.service DESTINATION lib/systemd/system)

--- a/ibarr.service.in
+++ b/ibarr.service.in
@@ -3,7 +3,7 @@ Description=Nvidia address and route userspace resolution services for Infiniban
 Documentation=https://github.com/Melanox/ip2gid/
 
 [Service]
-ExecStart=/usr/bin/ibarr
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/ibarr
 # Try to restrict it, because it hardly reads and writes files:
 PrivateTmp=yes
 ProtectHome=yes


### PR DESCRIPTION
Fixes https://github.com/Mellanox/ip2gid/issues/11.

When using relative paths in the `install` directive ([docs](https://cmake.org/cmake/help/latest/command/install.html)):

> If a relative path is given it is interpreted relative to the value of the [CMAKE_INSTALL_PREFIX](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html#variable:CMAKE_INSTALL_PREFIX) variable.

When no prefix is given, the default is `/usr/local`, so the service file would end up at `/usr/local/lib/systemd/system`. This is the right directory for files installed by the administrator according to [the systemd docs](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Unit%20File%20Load%20Path).

This doesn't work for local installs because systemd expects the service file in `$HOME/.local/share/systemd/user` and not `$HOME/.local/lib/systemd/system` ... But since the daemon expects to run as root anyway, this is not a big problem here.

Thank you in advance!